### PR TITLE
replace sassc-rails with dartsass-sprockets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,9 +5,9 @@ PATH
       actionpack (>= 5.0)
       actionview (>= 5.0)
       activerecord (>= 5.0)
+      dartsass-sprockets (~> 3.0)
       jquery-rails (>= 4.0)
       kaminari (>= 1.0)
-      sassc-rails (~> 2.1)
       selectize-rails (~> 0.6)
 
 GEM
@@ -115,6 +115,14 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    dartsass-ruby (3.0.1)
+      sass-embedded (~> 1.54)
+    dartsass-sprockets (3.0.0)
+      dartsass-ruby (~> 3.0)
+      railties (>= 4.0.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
     database_cleaner-active_record (2.1.0)
@@ -140,7 +148,6 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
-    ffi (1.15.5)
     formulaic (0.4.1)
       activesupport
       capybara
@@ -148,6 +155,7 @@ GEM
     front_matter_parser (1.0.1)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    google-protobuf (3.23.3)
     hashdiff (1.0.1)
     highline (2.1.0)
     i18n (1.14.1)
@@ -281,14 +289,9 @@ GEM
     rspec-support (3.12.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
+    sass-embedded (1.63.6)
+      google-protobuf (~> 3.23)
+      rake (>= 13.0.0)
     selectize-rails (0.12.6)
     selenium-webdriver (4.9.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -309,7 +312,7 @@ GEM
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.2)
-    tilt (2.1.0)
+    tilt (2.2.0)
     timecop (0.9.6)
     timeout (0.4.0)
     tzinfo (2.0.6)

--- a/administrate.gemspec
+++ b/administrate.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "jquery-rails", ">= 4.0"
   s.add_dependency "kaminari", ">= 1.0"
-  s.add_dependency "sassc-rails", "~> 2.1"
+  s.add_dependency "dartsass-sprockets", "~> 3.0"
   s.add_dependency "selectize-rails", "~> 0.6"
 
   s.description = <<-DESCRIPTION

--- a/lib/administrate/engine.rb
+++ b/lib/administrate/engine.rb
@@ -1,6 +1,6 @@
 require "jquery-rails"
 require "kaminari"
-require "sassc-rails"
+require "dartsass-sprockets"
 require "selectize-rails"
 require "sprockets/railtie"
 


### PR DESCRIPTION
Allow to use current CSS by using dartsass instead of sassc.

This should allow to go on with current CSS.